### PR TITLE
Fix bug with referencing luau_lsp instead of lua_ls

### DIFF
--- a/nvim/lua/plugins/lsp.lua
+++ b/nvim/lua/plugins/lsp.lua
@@ -85,7 +85,7 @@ local runtime_path = vim.split(package.path, ';')
 table.insert(runtime_path, 'lua/?.lua')
 table.insert(runtime_path, 'lua/?/init.lua')
 
-require('lspconfig').luau_lsp.setup {
+require('lspconfig').lua_ls.setup {
   on_attach = on_attach,
   capabilities = capabilities,
   settings = {


### PR DESCRIPTION
While there is indeed a luau_lsp listed under the server configuration in https://github.com/neovim/nvim-lspconfig/tree/master/lua/lspconfig/server_configurations , the configuration settings that are being applied are according to the suggestions for lua_ls and not luau_lsp.

I should note that I am not running your Neovim config but I noticed this when I was referencing it for my own use.