### PR TITLE
tmux: Fix typo

### DIFF
--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -1,5 +1,5 @@
 source-file ~/.config/tmux/tmux.reset.conf
-set-option -g default-terminal 'screen-254color'
+set-option -g default-terminal 'screen-256color'
 set-option -g terminal-overrides ',xterm-256color:RGB'
 
 set -g prefix ^A


### PR DESCRIPTION
Fixes: https://github.com/omerxx/dotfiles/issues/4

I noticed this when watching https://www.youtube.com/watch?v=GH3kpsbbERo

The only other reference to `screen-254color` appears to be from someone who copied your config (https://github.com/catppuccin/tmux/issues/84#issuecomment-1849100577)