### PR TITLE
feature: use fzf to open file from terminal in neovim, with file previews

### DIFF
--- a/zshrc/.zshrc
+++ b/zshrc/.zshrc
@@ -111,6 +111,10 @@ alias gr='~/go/src/github.com/tomnomnom/gf/gf'
 # FZF
 export FZF_DEFAULT_COMMAND='fd --type f --hidden --follow'
 [ -f ~/.fzf.zsh ] && source ~/.fzf.zsh
+# FZF, open selected file in nvim with preview!
+alias of="fzf --preview 'bat --style=numbers --color=always --line-range :500 {}' | xargs nvim"
+
+
 
 export PATH=/opt/homebrew/bin:$PATH
 


### PR DESCRIPTION
Just a cool alias I added to my personal .zshrc that's based on yours, by typing ''of'' (initials of **openfile**) into the terminal, it pops up an FZF search in the current dir with file previews, when you hit enter it opens the file in Neovim.
I just didn't find anything similar in your setup and found this very helpful for me on some occasions.

<img width="1349" alt="image" src="https://github.com/omerxx/dotfiles/assets/83507910/06aeb69c-3b57-415a-8047-a4b9e15f7249">
