### PR TITLE
Add Nushell highlighting in neovim

### DIFF
--- a/nvim/lazyvim.json
+++ b/nvim/lazyvim.json
@@ -9,6 +9,7 @@
     "lazyvim.plugins.extras.lang.helm",
     "lazyvim.plugins.extras.lang.json",
     "lazyvim.plugins.extras.lang.markdown",
+    "lazyvim.plugins.extras.lang.nushell",
     "lazyvim.plugins.extras.lang.yaml",
     "lazyvim.plugins.extras.util.rest"
   ],


### PR DESCRIPTION
You got me into Nushell.

Then I decided to try Neovim using your config files and I was surprised `.nu` files were not highlighted by default.

Anyway, thanks for the great yt channel!